### PR TITLE
Spurious heading and trailing spaces should be stripped

### DIFF
--- a/Flickr30k/flickr_stats.py
+++ b/Flickr30k/flickr_stats.py
@@ -20,7 +20,7 @@ def normalize_label(label):
     label = label.lower().replace(' , ',' ').replace(' + ', ' ')
     label = label.replace('(','').replace(')','')
     label = label.replace(' & ', ' ').replace('  ', ' ')
-    return label
+    return label.strip()
 
 def all_labels():
     "Get number of labels."


### PR DESCRIPTION
There are cases where the labels are left with spurious spaces e.g. " people" =)

----

Also, here's a one-liner `re.sub` for `normalize_label()`, maybe you'll like it more:

```python
def normalize_label(label):
    return ' '.join(re.sub('@ | , | \+ |\(|\)| & ', ' ', label.lower()).split())
```

It should work the same with some assertion test:

```python
from lazyme import find_files
import re

# Person annotations.
pattern = re.compile('\[/EN#\d+/people (.*?)\]', re.IGNORECASE)

def normalize_label(label):
    "Normalize the label."
    label = label.replace('@ ','')
    label = label.lower().replace(' , ',' ').replace(' + ', ' ')
    label = label.replace('(','').replace(')','')
    label = label.replace(' & ', ' ').replace('  ', ' ')
    return label.strip()

def llabel(label):
    return ' '.join(re.sub('@ | , | \+ |\(|\)| & ', ' ', label.lower()).split())

for filename in find_files('Flickr30k/resources/Sentences/', '*.txt'):
    with open(filename) as fin:
        
        raw = pattern.findall(fin.read())
        normalized = [normalize_label(txt) for txt in raw]
        llized = [llabel(txt) for txt in raw]
        for l1, l2 in zip(normalized, llized):
            assert l1 == l2
```